### PR TITLE
inital notebook for DataCite Metadata Gaps for Disciplinary Analysis

### DIFF
--- a/mdc-dataset-discipline/README.md
+++ b/mdc-dataset-discipline/README.md
@@ -1,0 +1,19 @@
+## [maDMPs](https://www.rd-alliance.org/madmps) Dataset citations and usage by discipline. 
+
+### Jupyter Notebook:
+
+#### Metadata Gaps
+
+[![Identifier](https://img.shields.io/badge/doi-10.14454%2Fw67k--5373-blue)](https://doi.org/10.14454/w67k-5373)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/datacite/pidgraph-notebooks-python/master?urlpath=lab/tree/dmp%2Fuser-story-single-dmp-connections.ipynb)
+
+[Go to NBViewer](https://nbviewer.jupyter.org/github/datacite/pidgraph-notebooks-python/blob/master/dmp/user-story-single-dmp-connections.ipynb)
+
+
+#### Contribute
+
+- Clone the project
+- Create a Branch
+- Implement your feature or make a bug fix
+- Do not mess with version or history
+- Commit, push and make a Pull Request. 

--- a/mdc-dataset-discipline/README.md
+++ b/mdc-dataset-discipline/README.md
@@ -1,13 +1,13 @@
-## [maDMPs](https://www.rd-alliance.org/madmps) Dataset citations and usage by discipline. 
+## [Make Data Count](https://makedatacount.org/) Dataset citations and usage by discipline. 
 
 ### Jupyter Notebook:
 
-#### Metadata Gaps
+#### Descriptive Stats for Discipline Use Case
 
 [![Identifier](https://img.shields.io/badge/doi-10.14454%2Fw67k--5373-blue)](https://doi.org/10.14454/w67k-5373)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/datacite/pidgraph-notebooks-python/master?urlpath=lab/tree/dmp%2Fuser-story-single-dmp-connections.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/datacite/pidgraph-notebooks-python/master?urlpath=lab/tree/mdc-dataset-discipline%2Fdiscipline-data-gaps.ipynb)
 
-[Go to NBViewer](https://nbviewer.jupyter.org/github/datacite/pidgraph-notebooks-python/blob/master/dmp/user-story-single-dmp-connections.ipynb)
+[Go to NBViewer](https://nbviewer.jupyter.org/github/datacite/pidgraph-notebooks-python/blob/master/mdc-dataset-discipline/discipline-data-gaps.ipynb)
 
 
 #### Contribute

--- a/mdc-dataset-discipline/codemeta.json
+++ b/mdc-dataset-discipline/codemeta.json
@@ -1,0 +1,35 @@
+{
+    "@context": "https://raw.githubusercontent.com/codemeta/codemeta/master/codemeta.jsonld",
+    "@type": "SoftwareSourceCode",
+    "@id": "https://doi.org/10.14454/w67k-5373",
+    "name": "Datasets usage and citations metadata analysis",
+    "authors": [
+      {
+        "name": "Garza, Kristian",
+        "nameType": "Personal",
+        "givenName": "Kristian",
+        "familyName": "Garza",
+        "affiliation": [],
+        "nameIdentifiers": [
+          {
+            "schemeUri": "https://orcid.org",
+            "nameIdentifier": "https://orcid.org/0000-0003-3484-6875",
+            "nameIdentifierScheme": "ORCID"
+          }
+        ]
+      }
+    ],
+    "description": "Bibliometricians need to have an overall picture of the DataCite data corpus in order to do the analysis. In order to provide this, we will create a notebook with descriptive statistics about the Datacite data corpus broken up by the different dimensions of interest (viz. Discipline, career status, usage, and citations). This document aims to make the first step into creating that notebook by looking directly at the DOI index and exploring the descriptive statistics that will be used.",
+    "version": "1.0.0",
+    "tags": [
+      "pid graph",
+      "pid",
+      "graphql",
+      "bibliometrics",
+      "Make data Count",
+      "jupyter"
+    ],
+    "datePublished": 2020,
+    "publisher": "DataCite",
+    "license": "https://opensource.org/licenses/MIT"
+  }

--- a/mdc-dataset-discipline/discipline-data-gaps.ipynb
+++ b/mdc-dataset-discipline/discipline-data-gaps.ipynb
@@ -1,0 +1,2582 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "Python 3.8.5 64-bit",
+   "display_name": "Python 3.8.5 64-bit",
+   "metadata": {
+    "interpreter": {
+     "hash": "1ee38ef4a5a9feb55287fd749643f13d043cb0a7addaab2a9c224cbe137c0062"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DataCite Corpus descriptive Statistics\n",
+    "\n",
+    "Bibliometricians need to have an overall picture of the DataCite data corpus in order to do the analysis. In order to provide this, we will create a notebook with descriptive statistics about the Datacite data corpus broken up by the different dimensions of interest (viz. Discipline, career status, usage, and citations). This document aims to make the first step into creating that notebook by looking directly at the DOI index and exploring the descriptive statistics that will be used.\n",
+    "\n",
+    "I have broken the descriptive statistics by the two main sections one per each use case: discipline and career status. Each section then breaks down the data by different dimensions: citations and usage.\n",
+    "\n",
+    "I found that we have a limited number of datasets with disciplinary information that have citations,  views, and downloads. We must implement methods to enrich our metadata to have significant a sample. The proxy approach is a good way to enrich the metadata in terms of discipline and it would help to get a larger data corpus to the bibliometricians. However, the fact that none of the disciplinary repositories is sending usage reports about the datasets might limit the usefulness of that data. \n"
+   ]
+  },
+  {
+   "source": [
+    "## Set up\n",
+    "\n",
+    "Installing and importing  packages."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Install required Python packages\n",
+    "!pip install dfply altair altair_saver vega altair_viewer dash==1.16.3 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 172,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import numpy as np\n",
+    "from dfply import *\n",
+    "import altair.vega.v5 as alt\n",
+    "from altair_saver import save\n",
+    "import altair.vegalite.v4 as lite\n",
+    "# import plotly.graph_objects as go\n",
+    "import pandas as pd\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare the GraphQL client\n",
+    "import requests\n",
+    "from IPython.display import display, Markdown\n",
+    "from gql import gql, Client\n",
+    "from gql.transport.requests import RequestsHTTPTransport\n",
+    "\n",
+    "_transport = RequestsHTTPTransport(\n",
+    "    url='https://api.datacite.org/graphql',\n",
+    "    use_json=True,\n",
+    ")\n",
+    "\n",
+    "client = Client(\n",
+    "    transport=_transport,\n",
+    "    fetch_schema_from_transport=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fetching Data\n",
+    "\n",
+    "We obtain all the data from the DataCite GraphQL API. All the queries are for datasets DOIs that include Field of Science information in their metadata. We have three different queries:\n",
+    "\n",
+    "- DOIs with citations\n",
+    "- DOIs with views\n",
+    "- DOIs with downloads\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " # Generate the GraphQL query to retrieve up to 100 outputs of University of Oxford, with at least 100 views each.\n",
+    "\n",
+    "query_params = {\n",
+    "    \"query\" : \"subjects.subjectScheme:\\\"Fields of Science and Technology (FOS)\\\"\",\n",
+    "}\n",
+    "\n",
+    "datasetsQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "{\n",
+    "  datasets {\n",
+    "    totalCount\n",
+    "  }\n",
+    "}\n",
+    "\"\"\")\n",
+    "\n",
+    "\n",
+    "fOSQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "{\n",
+    "  datasets(query: $query) {\n",
+    "    totalCount\n",
+    "  }\n",
+    "}\n",
+    "\"\"\")\n",
+    "\n",
+    "\n",
+    "citationsQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "{\n",
+    "  datasets(query: $query,  hasCitations:1) {\n",
+    "    totalCount\n",
+    "    fieldsOfScience{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    published{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    licenses{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    affiliations{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\"\"\")\n",
+    "\n",
+    "viewsQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "{\n",
+    "  datasets(query:$query, hasViews:1) {\n",
+    "    totalCount\n",
+    "    fieldsOfScience{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    published{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    licenses{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    affiliations{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "\"\"\")\n",
+    "\n",
+    "downloadsQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "{\n",
+    "  datasets(query:$query, hasDownloads:1) {\n",
+    "    totalCount\n",
+    "    fieldsOfScience{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    published{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    licenses{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "    affiliations{\n",
+    "      title\n",
+    "      count\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 175,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data(type):\n",
+    "    \"\"\"Gets the data from the graphql api into an object\n",
+    "\n",
+    "    Parameters:\n",
+    "    type (string): Controlled vocabulary for type of data\n",
+    "\n",
+    "    Returns:\n",
+    "    object:Returning object reponse\n",
+    "\n",
+    "   \"\"\"\n",
+    "    if type == \"citations\":\n",
+    "        return client.execute(citationsQuery, variable_values=json.dumps(query_params))[\"datasets\"]\n",
+    "    elif type == \"views\":\n",
+    "        return client.execute(viewsQuery, variable_values=json.dumps(query_params))[\"datasets\"]\n",
+    "    elif type == \"downloads\":\n",
+    "        return client.execute(downloadsQuery, variable_values=json.dumps(query_params))[\"datasets\"]\n",
+    "    elif type == \"fos\":\n",
+    "        return client.execute(fOSQuery, variable_values=json.dumps(query_params))[\"datasets\"]\n",
+    "    else:\n",
+    "        return client.execute(datasetsQuery, variable_values=json.dumps(query_params))[\"datasets\"]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "usage = get_data(\"views\")\n",
+    "citations = get_data(\"citations\")\n",
+    "datasest = get_data(\"datasets\")\n",
+    "fos = get_data(\"fos\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Transformation\n",
+    "\n",
+    "Simple transformations are performed to convert the graphql response into an dataframe that can be used in visulisations and tables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def transform_distributions(dataframe, total):\n",
+    "    \"\"\"Modifies each item to include attributes needed for the node visulisation\n",
+    "\n",
+    "    Parameters:\n",
+    "    dataframe (dataframe): A dataframe with all the itemss\n",
+    "    parent (int): The id of the parent node\n",
+    "\n",
+    "    Returns:\n",
+    "    dataframe:Returning vthe same dataframe with new attributes\n",
+    "\n",
+    "   \"\"\"\n",
+    "    # dataframe = {title: \"Other\", count: total}\n",
+    "    if (dataframe) is None:\n",
+    "        return pd.DataFrame() \n",
+    "    else: \n",
+    "        return (dataframe >>\n",
+    "        mutate(\n",
+    "            perc = (X['count']/total)*100\n",
+    "        ) \n",
+    "        )\n",
+    "  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def processTable(data, type):\n",
+    "    # data = get_data(\"citations\")\n",
+    "    if len(data[type]) == 0:\n",
+    "        return None\n",
+    "    else:\n",
+    "        table = pd.DataFrame(data[type],columns=data[type][0].keys())\n",
+    "    return transform_distributions(table, data['totalCount']) "
+   ]
+  },
+  {
+   "source": [
+    "## Descriptive Statistics Visulisation\n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "I have broken the descriptive statistics by the two main sections one per each type of data: citations and usage."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "## Citations stats with disciplinary information"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "domain": {
+          "x": [
+           0,
+           1
+          ],
+          "y": [
+           0,
+           1
+          ]
+         },
+         "mode": "number+delta",
+         "title": {
+          "text": "Cited Datasets"
+         },
+         "type": "indicator",
+         "value": 830
+        }
+       ],
+       "layout": {
+        "paper_bgcolor": "lightgray",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "\n",
+    "fig = go.Figure(go.Indicator(\n",
+    "    mode = \"number+delta\",\n",
+    "    value = citations[\"totalCount\"],\n",
+    "    title= {'text': \"Cited Datasets\"},\n",
+    "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
+    "fig.update_layout(paper_bgcolor = \"lightgray\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                                            title  count      perc\n",
+       "0              University of California, Berkeley      6  0.722892\n",
+       "1                                 Rice University      5  0.602410\n",
+       "2                         University of Melbourne      5  0.602410\n",
+       "3                           Utah State University      4  0.481928\n",
+       "4                 University of California System      4  0.481928\n",
+       "5  French National Centre for Scientific Research      4  0.481928\n",
+       "6                           University of Florida      4  0.481928\n",
+       "7                           University of Arizona      4  0.481928\n",
+       "8                              Cornell University      4  0.481928\n",
+       "9                         University of Sheffield      4  0.481928"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>6</td>\n      <td>0.722892</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 180
+    }
+   ],
+   "source": [
+    "processTable(citations, \"affiliations\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                                      title  count       perc\n",
+       "0  Earth and related environmental sciences    349  42.048193\n",
+       "1                                 Sociology    146  17.590361\n",
+       "2                       Biological sciences    141  16.987952\n",
+       "3                           Social sciences     55   6.626506\n",
+       "4                         Clinical medicine     30   3.614458\n",
+       "5         Computer and information sciences     23   2.771084\n",
+       "6                           Health sciences     21   2.530120\n",
+       "7                  Languages and literature     16   1.927711\n",
+       "8                                Psychology     15   1.807229\n",
+       "9                         Physical sciences     12   1.445783"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>42.048193</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>17.590361</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>141</td>\n      <td>16.987952</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>6.626506</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>3.614458</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>2.771084</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>1.927711</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>1.807229</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>1.445783</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 181
+    }
+   ],
+   "source": [
+    "processTable(citations, \"fieldsOfScience\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "   title  count       perc\n",
+       "0   2020    149  17.951807\n",
+       "1   2019     67   8.072289\n",
+       "2   2018     78   9.397590\n",
+       "3   2017     45   5.421687\n",
+       "4   2016     65   7.831325\n",
+       "5   2015     51   6.144578\n",
+       "6   2014     29   3.493976\n",
+       "7   2013     21   2.530120\n",
+       "8   2012     19   2.289157\n",
+       "9   2011    105  12.650602\n",
+       "10  2010     17   2.048193"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>149</td>\n      <td>17.951807</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>8.072289</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>9.397590</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>5.421687</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>7.831325</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>6.144578</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>3.493976</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>2.289157</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>12.650602</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>2.048193</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 182
+    }
+   ],
+   "source": [
+    "processTable(citations, \"published\") \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 183,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             title  count       perc\n",
+       "0          CC0-1.0    209  25.180723\n",
+       "1        CC-BY-4.0    129  15.542169\n",
+       "2        CC-BY-3.0      4   0.481928\n",
+       "3     cc-by-nd-2.0      3   0.361446\n",
+       "4              MIT      2   0.240964\n",
+       "5     CC-BY-NC-4.0      1   0.120482\n",
+       "6  CC-BY-NC-ND-4.0      1   0.120482\n",
+       "7  CC-BY-NC-SA-4.0      1   0.120482\n",
+       "8     CC-BY-SA-4.0      1   0.120482\n",
+       "9          GPL-3.0      1   0.120482"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>209</td>\n      <td>25.180723</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>15.542169</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.361446</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.240964</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 183
+    }
+   ],
+   "source": [
+    "processTable(citations, \"licenses\") \n"
+   ]
+  },
+  {
+   "source": [
+    "Questions:\n",
+    "\n",
+    "- Why are there so few Datasets DOIs with citations?\n",
+    "  - There are obviously social reasons but we can focus on the technical reasons here:\n",
+    "    - There citations events in EventData still need to reach our DOI index. [Link](https://github.com/datacite/datacite/issues/1082) \n",
+    "    - Citations counts from/to Crossref DOIs can be lowered if we have not indexed Crossref Metadata. [Link](https://github.com/datacite/datacite/issues/1082) \n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "## Usage stats with disciplinary information"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "domain": {
+          "x": [
+           0,
+           1
+          ],
+          "y": [
+           0,
+           1
+          ]
+         },
+         "mode": "number+delta",
+         "title": {
+          "text": "Viewed Datasets"
+         },
+         "type": "indicator",
+         "value": 244
+        }
+       ],
+       "layout": {
+        "paper_bgcolor": "lightgray",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "fig = go.Figure(go.Indicator(\n",
+    "    mode = \"number+delta\",\n",
+    "    value = usage[\"totalCount\"],\n",
+    "    title= {'text': \"Viewed Datasets\"},\n",
+    "    # delta = {'position': \"top\", 'reference': usage[\"published\"][0][\"count\"]},\n",
+    "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
+    "\n",
+    "fig.update_layout(paper_bgcolor = \"lightgray\")\n",
+    "\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 193,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                                      title  count       perc\n",
+       "0                                 Sociology    166  68.032787\n",
+       "1                       Biological sciences     39  15.983607\n",
+       "2                         Clinical medicine     13   5.327869\n",
+       "3                           Health sciences      9   3.688525\n",
+       "4         Computer and information sciences      4   1.639344\n",
+       "5                      Chemical engineering      2   0.819672\n",
+       "6  Earth and related environmental sciences      2   0.819672\n",
+       "7                  Languages and literature      2   0.819672\n",
+       "8                     Medical biotechnology      2   0.819672\n",
+       "9                         Chemical sciences      1   0.409836"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Sociology</td>\n      <td>166</td>\n      <td>68.032787</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Biological sciences</td>\n      <td>39</td>\n      <td>15.983607</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Clinical medicine</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Health sciences</td>\n      <td>9</td>\n      <td>3.688525</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Computer and information sciences</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Chemical engineering</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Earth and related environmental sciences</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Medical biotechnology</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Chemical sciences</td>\n      <td>1</td>\n      <td>0.409836</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 193
+    }
+   ],
+   "source": [
+    "processTable(usage, \"fieldsOfScience\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                                title  count      perc\n",
+       "0  University of California, Berkeley      7  2.868852\n",
+       "1                     Rice University      5  2.049180\n",
+       "2               Utah State University      5  2.049180\n",
+       "3             University of Melbourne      5  2.049180\n",
+       "4                  Harvard University      5  2.049180\n",
+       "5              University of Helsinki      5  2.049180\n",
+       "6             University of Sheffield      5  2.049180\n",
+       "7               University of Montana      4  1.639344\n",
+       "8                Princeton University      4  1.639344\n",
+       "9     University of California System      4  1.639344"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>7</td>\n      <td>2.868852</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Utah State University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Harvard University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>University of Helsinki</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Sheffield</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Montana</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Princeton University</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 194
+    }
+   ],
+   "source": [
+    "processTable(usage, \"affiliations\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "   title  count       perc\n",
+       "0   2020     23   9.426230\n",
+       "1   2019     53  21.721311\n",
+       "2   2018     31  12.704918\n",
+       "3   2017     21   8.606557\n",
+       "4   2016     37  15.163934\n",
+       "5   2015     26  10.655738\n",
+       "6   2014     19   7.786885\n",
+       "7   2013     11   4.508197\n",
+       "8   2012     13   5.327869\n",
+       "9   2011      4   1.639344\n",
+       "10  2010      2   0.819672"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>23</td>\n      <td>9.426230</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>53</td>\n      <td>21.721311</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>31</td>\n      <td>12.704918</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>21</td>\n      <td>8.606557</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>37</td>\n      <td>15.163934</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>26</td>\n      <td>10.655738</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>19</td>\n      <td>7.786885</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>11</td>\n      <td>4.508197</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 195
+    }
+   ],
+   "source": [
+    "processTable(usage, \"published\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 196,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "       title  count       perc\n",
+       "0    CC0-1.0    226  92.622951\n",
+       "1  CC-BY-4.0      2   0.819672"
+      ],
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>226</td>\n      <td>92.622951</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 196
+    }
+   ],
+   "source": [
+    "processTable(usage, \"licenses\")"
+   ]
+  },
+  {
+   "source": [
+    "Questions:\n",
+    "\n",
+    "- Why are there so few Datasets DOIs with usage information?\n",
+    "  - Currently just a handful of repositories have been sending usage statistics."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "## Further Visulisation [WIP]\n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 197,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def vega_donut_template(data):\n",
+    "    \"\"\"Injects data into the vega specification\n",
+    "\n",
+    "    Parameters:\n",
+    "    data (array): Array of nodes\n",
+    "\n",
+    "    Returns:\n",
+    "    VegaSpec:Specification with data\n",
+    "\n",
+    "   \"\"\"\n",
+    "    return \"\"\"\n",
+    "{\n",
+    "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\",\n",
+    "  \"description\": \"A simple donut chart with embedded data.\",\n",
+    "  \"padding\": {\"left\": 55, \"top\": 10, \"right\": 10, \"bottom\": 10},\n",
+    "  \"width\": 200,\n",
+    "  \"height\": 200,\n",
+    "  \"data\": {\n",
+    "    \"values\": \"\"\" + data + \"\"\"\n",
+    "  },\n",
+    "  \"layer\": [\n",
+    "    {\n",
+    "      \"mark\": {\n",
+    "        \"type\": \"arc\",\n",
+    "        \"innerRadius\": 68,\n",
+    "        \"outerRadius\": 90,\n",
+    "        \"cursor\": \"pointer\",\n",
+    "        \"tooltip\": true\n",
+    "      },\n",
+    "      \"encoding\": {\n",
+    "        \"theta\": {\n",
+    "          \"field\": \"count\",\n",
+    "          \"type\": \"quantitative\",\n",
+    "          \"sort\": \"descending\"\n",
+    "        },\n",
+    "        \"color\": {\n",
+    "          \"field\": \"title\",\n",
+    "          \"type\": \"nominal\",\n",
+    "          \"title\": \"type\",\n",
+    "          \"scale\": {\n",
+    "            \"range\": [\n",
+    "              \"#fccde5\",\n",
+    "              \"#fdb462\",\n",
+    "              \"#fb8072\",\n",
+    "              \"#fb8072\",\n",
+    "              \"#b3de69\",\n",
+    "              \"#bc80bd\",\n",
+    "              \"#fccde5\",\n",
+    "              \"#8dd3c7\",\n",
+    "              \"#ffed6f\",\n",
+    "              \"#d9d9d9\",\n",
+    "              \"#ffffb3\",\n",
+    "              \"#bebada\",\n",
+    "              \"#80b1d3\",\n",
+    "              \"#ccebc5\",\n",
+    "              \"#d9d9d9\"\n",
+    "            ],\n",
+    "            \"domain\": [\n",
+    "              \"2020\",\n",
+    "              \"2019\",\n",
+    "              \"2018\",\n",
+    "              \"2017\",\n",
+    "              \"2016\",\n",
+    "              \"2015\",\n",
+    "              \"2014\",\n",
+    "              \"Model\",\n",
+    "              \"Physical Object\",\n",
+    "              \"Service\",\n",
+    "              \"Sound\",\n",
+    "              \"Software\",\n",
+    "              \"Text\",\n",
+    "              \"Workflow\",\n",
+    "              \"Other\"\n",
+    "            ]\n",
+    "          }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    {\n",
+    "      \"mark\": {\n",
+    "        \"type\": \"text\",\n",
+    "        \"fill\": \"#767676\",\n",
+    "        \"align\": \"center\",\n",
+    "        \"baseline\": \"middle\",\n",
+    "        \"fontSize\": 27\n",
+    "      },\n",
+    "      \"encoding\": {\"text\": {\"value\": \"33\"}}\n",
+    "    }\n",
+    "  ],\n",
+    "  \"view\": {\"stroke\": \"none\"}\n",
+    "}\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 198,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def vega_grid_template(data):\n",
+    "    \"\"\"Injects data into the vega specification\n",
+    "\n",
+    "    Parameters:\n",
+    "    data (array): Array of nodes\n",
+    "\n",
+    "    Returns:\n",
+    "    VegaSpec:Specification with data\n",
+    "\n",
+    "   \"\"\"\n",
+    "    return \"\"\"\n",
+    "{\n",
+    "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\",\n",
+    "  \"description\": \"Two vertically concatenated charts that show a histogram of precipitation in Seattle and the relationship between min and max temperature.\",\n",
+    "  \"data\": {\n",
+    "    \"url\": \"data/weather.csv\"\n",
+    "  },\n",
+    "\n",
+    "  \"vconcat\": [\n",
+    "    {\n",
+    "     \"\"\" + total + \"\"\"\n",
+    "    },\n",
+    "    {\n",
+    "     \"\"\" + discipline_distribution + \"\"\"\n",
+    "    },\n",
+    "    {\n",
+    "     \"\"\" + affiliation_distribution + \"\"\"\n",
+    "    },\n",
+    "  ]\n",
+    "}\n",
+    "\n",
+    "    \"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 199,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "ValidationError",
+     "evalue": "'arc' is not one of ['area', 'bar', 'line', 'image', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square', 'geoshape']\n\nFailed validating 'enum' in schema[3]['properties']['type']:\n    {'description': 'All types of primitive marks.',\n     'enum': ['area',\n              'bar',\n              'line',\n              'image',\n              'trail',\n              'point',\n              'text',\n              'tick',\n              'rect',\n              'rule',\n              'circle',\n              'square',\n              'geoshape'],\n     'type': 'string'}\n\nOn instance['type']:\n    'arc'",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-199-82c7246679a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mchart\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlite\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVegaLite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvega_donut_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"published\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mchart\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/altair/utils/display.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, spec, validate)\u001b[0m\n\u001b[1;32m    121\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    122\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mvalidate\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 123\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_validate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    124\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    125\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_validate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/altair/utils/display.py\u001b[0m in \u001b[0;36m_validate\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    127\u001b[0m         \u001b[0;34m\"\"\"Validate the spec against the schema.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    128\u001b[0m         \u001b[0mschema_dict\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpkgutil\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mschema_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"utf-8\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 129\u001b[0;31m         \u001b[0mvalidate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mschema_dict\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    130\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    131\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_repr_mimebundle_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/jsonschema/validators.py\u001b[0m in \u001b[0;36mvalidate\u001b[0;34m(instance, schema, cls, *args, **kwargs)\u001b[0m\n\u001b[1;32m    932\u001b[0m     \u001b[0merror\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbest_match\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalidator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_errors\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minstance\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    933\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0merror\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 934\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    935\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    936\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValidationError\u001b[0m: 'arc' is not one of ['area', 'bar', 'line', 'image', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square', 'geoshape']\n\nFailed validating 'enum' in schema[3]['properties']['type']:\n    {'description': 'All types of primitive marks.',\n     'enum': ['area',\n              'bar',\n              'line',\n              'image',\n              'trail',\n              'point',\n              'text',\n              'tick',\n              'rect',\n              'rule',\n              'circle',\n              'square',\n              'geoshape'],\n     'type': 'string'}\n\nOn instance['type']:\n    'arc'"
+     ]
+    }
+   ],
+   "source": [
+    "chart = lite.VegaLite(json.loads(vega_donut_template(json.dumps(get_data(\"\")[\"published\"]))))\n",
+    "chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vega_hist_template(data):\n",
+    "    \"\"\"Injects data into the vega specification\n",
+    "\n",
+    "    Parameters:\n",
+    "    data (array): Array of nodes\n",
+    "\n",
+    "    Returns:\n",
+    "    VegaSpec:Specification with data\n",
+    "\n",
+    "   \"\"\"\n",
+    "    return \"\"\"\n",
+    "{\n",
+    "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\",\n",
+    "  \"data\": {\"values\": \"\"\" + data + \"\"\"},\n",
+    "  \"padding\": {\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5},\n",
+    "  \"transform\": [\n",
+    "    {\"calculate\": \"toNumber(datum.title)\", \"as\": \"period\"},\n",
+    "    {\"calculate\": \"toNumber(datum.title)+1\", \"as\": \"bin_end\"},\n",
+    "    {\"filter\": \"toNumber(datum.title) >= 2010\"}\n",
+    "  ],\n",
+    "  \"width\": 242,\n",
+    "  \"mark\": {\"type\": \"bar\", \"cursor\": \"pointer\", \"tooltip\": true},\n",
+    "  \"selection\": {\n",
+    "    \"highlight\": {\"type\": \"single\", \"empty\": \"none\", \"on\": \"mouseover\"}\n",
+    "  },\n",
+    "  \"encoding\": {\n",
+    "    \"x\": {\n",
+    "      \"field\": \"period\",\n",
+    "      \"bin\": {\"binned\": true, \"step\": 1, \"maxbins\": 11},\n",
+    "      \"type\": \"quantitative\",\n",
+    "      \"axis\": {\n",
+    "        \"format\": \"1\"\n",
+    "      },\n",
+    "      \"scale\": {\"domain\": [2010, 2021]}\n",
+    "    },\n",
+    "    \"x2\": {\"field\": \"bin_end\"},\n",
+    "    \"y\": {\n",
+    "      \"field\": \"count\",\n",
+    "      \"type\": \"quantitative\",\n",
+    "      \"axis\": {\"format\": \",f\", \"tickMinStep\": 1}\n",
+    "    },\n",
+    "    \"color\": {\n",
+    "      \"field\": \"count\",\n",
+    "      \"scale\": {\"range\": [\"#1abc9c\"]},\n",
+    "      \"type\": \"nominal\",\n",
+    "      \"legend\": null,\n",
+    "      \"condition\": [{\"selection\": \"highlight\", \"value\": \"#34495e\"}]\n",
+    "    }\n",
+    "  },\n",
+    "  \"config\": {\n",
+    "    \"view\": {\"stroke\": null},\n",
+    "    \"axis\": {\"grid\": false, \"title\": \"donut\", \"labelFlush\": false}\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 197,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/html": "\n<div id=\"altair-viz-4ce04d0d882946ebbd8cafcb814965a5\"></div>\n<script type=\"text/javascript\">\n  (function(spec, embedOpt){\n    let outputDiv = document.currentScript.previousElementSibling;\n    if (outputDiv.id !== \"altair-viz-4ce04d0d882946ebbd8cafcb814965a5\") {\n      outputDiv = document.getElementById(\"altair-viz-4ce04d0d882946ebbd8cafcb814965a5\");\n    }\n    const paths = {\n      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.8.1?noext\",\n      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n    };\n\n    function loadScript(lib) {\n      return new Promise(function(resolve, reject) {\n        var s = document.createElement('script');\n        s.src = paths[lib];\n        s.async = true;\n        s.onload = () => resolve(paths[lib]);\n        s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n        document.getElementsByTagName(\"head\")[0].appendChild(s);\n      });\n    }\n\n    function showError(err) {\n      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n      throw err;\n    }\n\n    function displayChart(vegaEmbed) {\n      vegaEmbed(outputDiv, spec, embedOpt)\n        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n    }\n\n    if(typeof define === \"function\" && define.amd) {\n      requirejs.config({paths});\n      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n    } else if (typeof vegaEmbed === \"function\") {\n      displayChart(vegaEmbed);\n    } else {\n      loadScript(\"vega\")\n        .then(() => loadScript(\"vega-lite\"))\n        .then(() => loadScript(\"vega-embed\"))\n        .catch(showError)\n        .then(() => displayChart(vegaEmbed));\n    }\n  })({\"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\", \"data\": {\"values\": [{\"title\": \"2020\", \"count\": 23}, {\"title\": \"2019\", \"count\": 53}, {\"title\": \"2018\", \"count\": 31}, {\"title\": \"2017\", \"count\": 21}, {\"title\": \"2016\", \"count\": 37}, {\"title\": \"2015\", \"count\": 26}, {\"title\": \"2014\", \"count\": 19}, {\"title\": \"2013\", \"count\": 11}, {\"title\": \"2012\", \"count\": 13}, {\"title\": \"2011\", \"count\": 4}, {\"title\": \"2010\", \"count\": 2}]}, \"padding\": {\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}, \"transform\": [{\"calculate\": \"toNumber(datum.title)\", \"as\": \"period\"}, {\"calculate\": \"toNumber(datum.title)+1\", \"as\": \"bin_end\"}, {\"filter\": \"toNumber(datum.title) >= 2010\"}], \"width\": 242, \"mark\": {\"type\": \"bar\", \"cursor\": \"pointer\", \"tooltip\": true}, \"selection\": {\"highlight\": {\"type\": \"single\", \"empty\": \"none\", \"on\": \"mouseover\"}}, \"encoding\": {\"x\": {\"field\": \"period\", \"bin\": {\"binned\": true, \"step\": 1, \"maxbins\": 11}, \"type\": \"quantitative\", \"axis\": {\"format\": \"1\"}, \"scale\": {\"domain\": [2010, 2021]}}, \"x2\": {\"field\": \"bin_end\"}, \"y\": {\"field\": \"count\", \"type\": \"quantitative\", \"axis\": {\"format\": \",f\", \"tickMinStep\": 1}}, \"color\": {\"field\": \"count\", \"scale\": {\"range\": [\"#1abc9c\"]}, \"type\": \"nominal\", \"legend\": null, \"condition\": [{\"selection\": \"highlight\", \"value\": \"#34495e\"}]}}, \"config\": {\"view\": {\"stroke\": null}, \"axis\": {\"grid\": false, \"title\": null, \"labelFlush\": false}}}, {\"mode\": \"vega-lite\"});\n</script>",
+      "text/plain": [
+       "<altair.vegalite.v4.display.VegaLite at 0x1118feee0>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 197
+    }
+   ],
+   "source": [
+    "chart = lite.VegaLite(json.loads(vega_hist_template(json.dumps(get_data(\"\")[\"published\"]))))\n",
+    "chart"
+   ]
+  }
+ ]
+}

--- a/mdc-dataset-discipline/discipline-data-gaps.ipynb
+++ b/mdc-dataset-discipline/discipline-data-gaps.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,12 +73,12 @@
     "import altair.vegalite.v4 as lite\n",
     "# import plotly.graph_objects as go\n",
     "import pandas as pd\n",
-    "\n"
+    "import plotly.graph_objects as go\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 212,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -346,7 +346,7 @@
           "text": "Datasets"
          },
          "type": "indicator",
-         "value": 7615387
+         "value": 7627926
         }
        ],
        "layout": {
@@ -1174,7 +1174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1201,7 +1201,7 @@
           "text": "Datasets with FOS"
          },
          "type": "indicator",
-         "value": 455009
+         "value": 455944
         }
        ],
        "layout": {
@@ -2053,7 +2053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -2080,7 +2080,7 @@
           "text": "Cited Datasets (0.18%)"
          },
          "type": "indicator",
-         "value": 830
+         "value": 831
         }
        ],
        "layout": {
@@ -2912,7 +2912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -2920,21 +2920,21 @@
      "data": {
       "text/plain": [
        "                                            title  count      perc\n",
-       "0              University of California, Berkeley      6  0.001319\n",
-       "1                                 Rice University      5  0.001099\n",
-       "2                         University of Melbourne      5  0.001099\n",
-       "3                           Utah State University      4  0.000879\n",
-       "4                 University of California System      4  0.000879\n",
-       "5  French National Centre for Scientific Research      4  0.000879\n",
-       "6                           University of Florida      4  0.000879\n",
-       "7                           University of Arizona      4  0.000879\n",
-       "8                              Cornell University      4  0.000879\n",
-       "9                         University of Sheffield      4  0.000879"
+       "0                                 Rice University      5  0.601685\n",
+       "1              University of California, Berkeley      5  0.601685\n",
+       "2                         University of Melbourne      5  0.601685\n",
+       "3                           Utah State University      4  0.481348\n",
+       "4                 University of California System      4  0.481348\n",
+       "5  French National Centre for Scientific Research      4  0.481348\n",
+       "6                           University of Florida      4  0.481348\n",
+       "7                           University of Arizona      4  0.481348\n",
+       "8                              Cornell University      4  0.481348\n",
+       "9                         University of Sheffield      4  0.481348"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>6</td>\n      <td>0.001319</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.001099</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.001099</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.601685</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>University of California, Berkeley</td>\n      <td>5</td>\n      <td>0.601685</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.601685</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 230
+     "execution_count": 20
     }
    ],
    "source": [
@@ -2943,29 +2943,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "                                      title  count      perc\n",
-       "0  Earth and related environmental sciences    349  0.076702\n",
-       "1                                 Sociology    146  0.032087\n",
-       "2                       Biological sciences    141  0.030988\n",
-       "3                           Social sciences     55  0.012088\n",
-       "4                         Clinical medicine     30  0.006593\n",
-       "5         Computer and information sciences     23  0.005055\n",
-       "6                           Health sciences     21  0.004615\n",
-       "7                  Languages and literature     16  0.003516\n",
-       "8                                Psychology     15  0.003297\n",
-       "9                         Physical sciences     12  0.002637"
+       "                                      title  count       perc\n",
+       "0  Earth and related environmental sciences    349  41.997593\n",
+       "1                                 Sociology    146  17.569194\n",
+       "2                       Biological sciences    142  17.087846\n",
+       "3                           Social sciences     55   6.618532\n",
+       "4                         Clinical medicine     30   3.610108\n",
+       "5         Computer and information sciences     23   2.767750\n",
+       "6                           Health sciences     21   2.527076\n",
+       "7                  Languages and literature     16   1.925391\n",
+       "8                                Psychology     15   1.805054\n",
+       "9                         Physical sciences     12   1.444043"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>0.076702</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>0.032087</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>141</td>\n      <td>0.030988</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>0.012088</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>0.006593</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>0.005055</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>0.004615</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>0.003516</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>0.003297</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>0.002637</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>41.997593</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>17.569194</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>142</td>\n      <td>17.087846</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>6.618532</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>3.610108</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>2.767750</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>2.527076</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>1.925391</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>1.805054</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>1.444043</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 231
+     "execution_count": 21
     }
    ],
    "source": [
@@ -2974,30 +2974,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "   title  count      perc\n",
-       "0   2020    149  0.032747\n",
-       "1   2019     67  0.014725\n",
-       "2   2018     78  0.017143\n",
-       "3   2017     45  0.009890\n",
-       "4   2016     65  0.014285\n",
-       "5   2015     51  0.011209\n",
-       "6   2014     29  0.006374\n",
-       "7   2013     21  0.004615\n",
-       "8   2012     19  0.004176\n",
-       "9   2011    105  0.023076\n",
-       "10  2010     17  0.003736"
+       "   title  count       perc\n",
+       "0   2020    150  18.050542\n",
+       "1   2019     67   8.062575\n",
+       "2   2018     78   9.386282\n",
+       "3   2017     45   5.415162\n",
+       "4   2016     65   7.821901\n",
+       "5   2015     51   6.137184\n",
+       "6   2014     29   3.489771\n",
+       "7   2013     21   2.527076\n",
+       "8   2012     19   2.286402\n",
+       "9   2011    105  12.635379\n",
+       "10  2010     17   2.045728"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>149</td>\n      <td>0.032747</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>0.014725</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>0.017143</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>0.009890</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>0.014285</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>0.011209</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>0.006374</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>0.004615</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>0.004176</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>0.023076</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>0.003736</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>150</td>\n      <td>18.050542</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>8.062575</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>9.386282</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>5.415162</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>7.821901</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>6.137184</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>3.489771</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>2.527076</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>2.286402</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>12.635379</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>2.045728</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 232
+     "execution_count": 22
     }
    ],
    "source": [
@@ -3006,33 +3006,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "             title  count      perc\n",
-       "0          CC0-1.0    209  0.045933\n",
-       "1        CC-BY-4.0    129  0.028351\n",
-       "2        CC-BY-3.0      4  0.000879\n",
-       "3     cc-by-nd-2.0      3  0.000659\n",
-       "4              MIT      2  0.000440\n",
-       "5     CC-BY-NC-4.0      1  0.000220\n",
-       "6  CC-BY-NC-ND-4.0      1  0.000220\n",
-       "7  CC-BY-NC-SA-4.0      1  0.000220\n",
-       "8     CC-BY-SA-4.0      1  0.000220\n",
-       "9          GPL-3.0      1  0.000220"
+       "             title  count       perc\n",
+       "0          CC0-1.0    210  25.270758\n",
+       "1        CC-BY-4.0    129  15.523466\n",
+       "2        CC-BY-3.0      4   0.481348\n",
+       "3     cc-by-nd-2.0      3   0.361011\n",
+       "4              MIT      2   0.240674\n",
+       "5     CC-BY-NC-4.0      1   0.120337\n",
+       "6  CC-BY-NC-ND-4.0      1   0.120337\n",
+       "7  CC-BY-NC-SA-4.0      1   0.120337\n",
+       "8     CC-BY-SA-4.0      1   0.120337\n",
+       "9          GPL-3.0      1   0.120337"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>209</td>\n      <td>0.045933</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>0.028351</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.000659</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.000440</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>210</td>\n      <td>25.270758</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>15.523466</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.481348</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.361011</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.240674</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.120337</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.120337</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.120337</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.120337</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.120337</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 233
+     "execution_count": 26
     }
    ],
    "source": [
-    "processTable(citations, \"license) ) \n"
+    "processTable(citations, \"licenses\") \n"
    ]
   },
   {
@@ -3056,7 +3056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -3917,7 +3917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -3939,7 +3939,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Sociology</td>\n      <td>166</td>\n      <td>68.032787</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Biological sciences</td>\n      <td>39</td>\n      <td>15.983607</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Clinical medicine</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Health sciences</td>\n      <td>9</td>\n      <td>3.688525</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Computer and information sciences</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Chemical engineering</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Earth and related environmental sciences</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Medical biotechnology</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Chemical sciences</td>\n      <td>1</td>\n      <td>0.409836</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 222
+     "execution_count": 28
     }
    ],
    "source": [
@@ -3948,7 +3948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -3970,7 +3970,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>7</td>\n      <td>2.868852</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Utah State University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Harvard University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>University of Helsinki</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Sheffield</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Montana</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Princeton University</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 223
+     "execution_count": 29
     }
    ],
    "source": [
@@ -3979,7 +3979,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -4002,7 +4002,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>23</td>\n      <td>9.426230</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>53</td>\n      <td>21.721311</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>31</td>\n      <td>12.704918</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>21</td>\n      <td>8.606557</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>37</td>\n      <td>15.163934</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>26</td>\n      <td>10.655738</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>19</td>\n      <td>7.786885</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>11</td>\n      <td>4.508197</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 224
+     "execution_count": 30
     }
    ],
    "source": [
@@ -4011,7 +4011,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -4025,7 +4025,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>226</td>\n      <td>92.622951</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 225
+     "execution_count": 31
     }
    ],
    "source": [
@@ -4051,7 +4051,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 32,
    "metadata": {
     "tags": []
    },
@@ -4153,7 +4153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 33,
    "metadata": {
     "tags": []
    },
@@ -4195,7 +4195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -4205,7 +4205,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-228-82c7246679a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mchart\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlite\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVegaLite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvega_donut_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"published\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mchart\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-34-82c7246679a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mchart\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlite\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVegaLite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvega_donut_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"published\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mchart\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mKeyError\u001b[0m: 'published'"
      ]
     }

--- a/mdc-dataset-discipline/discipline-data-gaps.ipynb
+++ b/mdc-dataset-discipline/discipline-data-gaps.ipynb
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +124,7 @@
     "    \"query\" : \"subjects.subjectScheme:\\\"Fields of Science and Technology (FOS)\\\"\",\n",
     "}\n",
     "\n",
-    "datasetsQuery = gql(\"\"\"query getOutputs($query: String)\n",
+    "datasetsQuery = gql(\"\"\"query \n",
     "{\n",
     "  datasets {\n",
     "    totalCount\n",
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,13 +247,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 211,
    "metadata": {},
    "outputs": [],
    "source": [
     "usage = get_data(\"views\")\n",
     "citations = get_data(\"citations\")\n",
-    "datasest = get_data(\"datasets\")\n",
+    "datasets = get_data(\"datasets\")\n",
     "fos = get_data(\"fos\")"
    ]
   },
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 212,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 213,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,6 +318,1716 @@
    "metadata": {}
   },
   {
+   "cell_type": "code",
+   "execution_count": 214,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "domain": {
+          "x": [
+           0,
+           1
+          ],
+          "y": [
+           0,
+           1
+          ]
+         },
+         "mode": "number+delta",
+         "title": {
+          "text": "Datasets"
+         },
+         "type": "indicator",
+         "value": 7615387
+        }
+       ],
+       "layout": {
+        "paper_bgcolor": "lightgray",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "fig = go.Figure(go.Indicator(\n",
+    "    mode = \"number+delta\",\n",
+    "    value = datasets[\"totalCount\"],\n",
+    "    title= {'text': \"Datasets\"},\n",
+    "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
+    "fig.update_layout(paper_bgcolor = \"lightgray\")\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "domain": {
+          "x": [
+           0,
+           1
+          ],
+          "y": [
+           0,
+           1
+          ]
+         },
+         "mode": "number+delta",
+         "title": {
+          "text": "Datasets with FOS"
+         },
+         "type": "indicator",
+         "value": 455009
+        }
+       ],
+       "layout": {
+        "paper_bgcolor": "lightgray",
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {}
+    }
+   ],
+   "source": [
+    "fig = go.Figure(go.Indicator(\n",
+    "    mode = \"number+delta\",\n",
+    "    value = fos[\"totalCount\"],\n",
+    "    title= {'text': \"Datasets with FOS\"},\n",
+    "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
+    "fig.update_layout(paper_bgcolor = \"lightgray\")\n",
+    "fig.show()"
+   ]
+  },
+  {
    "source": [
     "I have broken the descriptive statistics by the two main sections one per each type of data: citations and usage."
    ],
@@ -333,7 +2043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 216,
    "metadata": {},
    "outputs": [
     {
@@ -1189,7 +2899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 217,
    "metadata": {},
    "outputs": [
     {
@@ -1211,7 +2921,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>6</td>\n      <td>0.722892</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 180
+     "execution_count": 217
     }
    ],
    "source": [
@@ -1220,7 +2930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 218,
    "metadata": {},
    "outputs": [
     {
@@ -1242,7 +2952,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>42.048193</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>17.590361</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>141</td>\n      <td>16.987952</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>6.626506</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>3.614458</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>2.771084</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>1.927711</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>1.807229</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>1.445783</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 181
+     "execution_count": 218
     }
    ],
    "source": [
@@ -1251,7 +2961,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 219,
    "metadata": {},
    "outputs": [
     {
@@ -1274,7 +2984,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>149</td>\n      <td>17.951807</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>8.072289</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>9.397590</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>5.421687</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>7.831325</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>6.144578</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>3.493976</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>2.289157</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>12.650602</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>2.048193</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 182
+     "execution_count": 219
     }
    ],
    "source": [
@@ -1283,7 +2993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 220,
    "metadata": {},
    "outputs": [
     {
@@ -1305,7 +3015,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>209</td>\n      <td>25.180723</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>15.542169</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.361446</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.240964</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 183
+     "execution_count": 220
     }
    ],
    "source": [
@@ -1333,7 +3043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 221,
    "metadata": {},
    "outputs": [
     {
@@ -2191,7 +3901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 222,
    "metadata": {},
    "outputs": [
     {
@@ -2213,7 +3923,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Sociology</td>\n      <td>166</td>\n      <td>68.032787</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Biological sciences</td>\n      <td>39</td>\n      <td>15.983607</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Clinical medicine</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Health sciences</td>\n      <td>9</td>\n      <td>3.688525</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Computer and information sciences</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Chemical engineering</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Earth and related environmental sciences</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Medical biotechnology</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Chemical sciences</td>\n      <td>1</td>\n      <td>0.409836</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 193
+     "execution_count": 222
     }
    ],
    "source": [
@@ -2222,7 +3932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": 223,
    "metadata": {},
    "outputs": [
     {
@@ -2244,7 +3954,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>7</td>\n      <td>2.868852</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Utah State University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Harvard University</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>University of Helsinki</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Sheffield</td>\n      <td>5</td>\n      <td>2.049180</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Montana</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Princeton University</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 194
+     "execution_count": 223
     }
    ],
    "source": [
@@ -2253,7 +3963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 224,
    "metadata": {},
    "outputs": [
     {
@@ -2276,7 +3986,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>23</td>\n      <td>9.426230</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>53</td>\n      <td>21.721311</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>31</td>\n      <td>12.704918</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>21</td>\n      <td>8.606557</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>37</td>\n      <td>15.163934</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>26</td>\n      <td>10.655738</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>19</td>\n      <td>7.786885</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>11</td>\n      <td>4.508197</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>13</td>\n      <td>5.327869</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>4</td>\n      <td>1.639344</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 195
+     "execution_count": 224
     }
    ],
    "source": [
@@ -2285,7 +3995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 225,
    "metadata": {},
    "outputs": [
     {
@@ -2299,7 +4009,7 @@
       "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>226</td>\n      <td>92.622951</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>2</td>\n      <td>0.819672</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 196
+     "execution_count": 225
     }
    ],
    "source": [
@@ -2325,7 +4035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 226,
    "metadata": {
     "tags": []
    },
@@ -2427,7 +4137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 227,
    "metadata": {
     "tags": []
    },
@@ -2469,21 +4179,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [
     {
      "output_type": "error",
-     "ename": "ValidationError",
-     "evalue": "'arc' is not one of ['area', 'bar', 'line', 'image', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square', 'geoshape']\n\nFailed validating 'enum' in schema[3]['properties']['type']:\n    {'description': 'All types of primitive marks.',\n     'enum': ['area',\n              'bar',\n              'line',\n              'image',\n              'trail',\n              'point',\n              'text',\n              'tick',\n              'rect',\n              'rule',\n              'circle',\n              'square',\n              'geoshape'],\n     'type': 'string'}\n\nOn instance['type']:\n    'arc'",
+     "ename": "KeyError",
+     "evalue": "'published'",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-199-82c7246679a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mchart\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlite\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVegaLite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvega_donut_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"published\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mchart\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/altair/utils/display.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, spec, validate)\u001b[0m\n\u001b[1;32m    121\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    122\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalidate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mvalidate\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 123\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_validate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    124\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    125\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_validate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/altair/utils/display.py\u001b[0m in \u001b[0;36m_validate\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    127\u001b[0m         \u001b[0;34m\"\"\"Validate the spec against the schema.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    128\u001b[0m         \u001b[0mschema_dict\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mpkgutil\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mschema_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"utf-8\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 129\u001b[0;31m         \u001b[0mvalidate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mschema_dict\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    130\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    131\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_repr_mimebundle_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexclude\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/jsonschema/validators.py\u001b[0m in \u001b[0;36mvalidate\u001b[0;34m(instance, schema, cls, *args, **kwargs)\u001b[0m\n\u001b[1;32m    932\u001b[0m     \u001b[0merror\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbest_match\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalidator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0miter_errors\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minstance\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    933\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0merror\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 934\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    935\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    936\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValidationError\u001b[0m: 'arc' is not one of ['area', 'bar', 'line', 'image', 'trail', 'point', 'text', 'tick', 'rect', 'rule', 'circle', 'square', 'geoshape']\n\nFailed validating 'enum' in schema[3]['properties']['type']:\n    {'description': 'All types of primitive marks.',\n     'enum': ['area',\n              'bar',\n              'line',\n              'image',\n              'trail',\n              'point',\n              'text',\n              'tick',\n              'rect',\n              'rule',\n              'circle',\n              'square',\n              'geoshape'],\n     'type': 'string'}\n\nOn instance['type']:\n    'arc'"
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-228-82c7246679a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mchart\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlite\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVegaLite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mloads\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvega_donut_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"published\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mchart\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'published'"
      ]
     }
    ],

--- a/mdc-dataset-discipline/discipline-data-gaps.ipynb
+++ b/mdc-dataset-discipline/discipline-data-gaps.ipynb
@@ -297,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2029,6 +2029,16 @@
   },
   {
    "source": [
+    "Questions:\n",
+    "\n",
+    "- How can we enrich the metadata of the Datasets DOIs to include discplinary information?\n",
+    "    - On the best estimate,(viz, using the repository's discipline as a proxy for dataset discipline) we can increase the sample size from ~455K to ~1.8M DOIs with disciplinary metadata. Unfortunately, none of those 1.8M DOIs has “usage” information (none of the disciplinary repositories is sending usage reports), and only ~9K out of the 1.8M has at least a citation. \n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
     "I have broken the descriptive statistics by the two main sections one per each type of data: citations and usage."
    ],
    "cell_type": "markdown",
@@ -2043,7 +2053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 216,
+   "execution_count": 255,
    "metadata": {},
    "outputs": [
     {
@@ -2067,7 +2077,7 @@
          },
          "mode": "number+delta",
          "title": {
-          "text": "Cited Datasets"
+          "text": "Cited Datasets (0.18%)"
          },
          "type": "indicator",
          "value": 830
@@ -2888,10 +2898,13 @@
    ],
    "source": [
     "\n",
+    "perc = 100*(citations[\"totalCount\"]/fos[\"totalCount\"])\n",
+    "\n",
+    "\n",
     "fig = go.Figure(go.Indicator(\n",
     "    mode = \"number+delta\",\n",
     "    value = citations[\"totalCount\"],\n",
-    "    title= {'text': \"Cited Datasets\"},\n",
+    "    title= {'text': f\"Cited Datasets ({perc:.2f}%)\"},\n",
     "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
     "fig.update_layout(paper_bgcolor = \"lightgray\")\n",
     "fig.show()"
@@ -2899,7 +2912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": 230,
    "metadata": {},
    "outputs": [
     {
@@ -2907,21 +2920,21 @@
      "data": {
       "text/plain": [
        "                                            title  count      perc\n",
-       "0              University of California, Berkeley      6  0.722892\n",
-       "1                                 Rice University      5  0.602410\n",
-       "2                         University of Melbourne      5  0.602410\n",
-       "3                           Utah State University      4  0.481928\n",
-       "4                 University of California System      4  0.481928\n",
-       "5  French National Centre for Scientific Research      4  0.481928\n",
-       "6                           University of Florida      4  0.481928\n",
-       "7                           University of Arizona      4  0.481928\n",
-       "8                              Cornell University      4  0.481928\n",
-       "9                         University of Sheffield      4  0.481928"
+       "0              University of California, Berkeley      6  0.001319\n",
+       "1                                 Rice University      5  0.001099\n",
+       "2                         University of Melbourne      5  0.001099\n",
+       "3                           Utah State University      4  0.000879\n",
+       "4                 University of California System      4  0.000879\n",
+       "5  French National Centre for Scientific Research      4  0.000879\n",
+       "6                           University of Florida      4  0.000879\n",
+       "7                           University of Arizona      4  0.000879\n",
+       "8                              Cornell University      4  0.000879\n",
+       "9                         University of Sheffield      4  0.000879"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>6</td>\n      <td>0.722892</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.602410</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>University of California, Berkeley</td>\n      <td>6</td>\n      <td>0.001319</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Rice University</td>\n      <td>5</td>\n      <td>0.001099</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>University of Melbourne</td>\n      <td>5</td>\n      <td>0.001099</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Utah State University</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>University of California System</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>French National Centre for Scientific Research</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>University of Florida</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>University of Arizona</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Cornell University</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>University of Sheffield</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 217
+     "execution_count": 230
     }
    ],
    "source": [
@@ -2930,29 +2943,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
+   "execution_count": 231,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "                                      title  count       perc\n",
-       "0  Earth and related environmental sciences    349  42.048193\n",
-       "1                                 Sociology    146  17.590361\n",
-       "2                       Biological sciences    141  16.987952\n",
-       "3                           Social sciences     55   6.626506\n",
-       "4                         Clinical medicine     30   3.614458\n",
-       "5         Computer and information sciences     23   2.771084\n",
-       "6                           Health sciences     21   2.530120\n",
-       "7                  Languages and literature     16   1.927711\n",
-       "8                                Psychology     15   1.807229\n",
-       "9                         Physical sciences     12   1.445783"
+       "                                      title  count      perc\n",
+       "0  Earth and related environmental sciences    349  0.076702\n",
+       "1                                 Sociology    146  0.032087\n",
+       "2                       Biological sciences    141  0.030988\n",
+       "3                           Social sciences     55  0.012088\n",
+       "4                         Clinical medicine     30  0.006593\n",
+       "5         Computer and information sciences     23  0.005055\n",
+       "6                           Health sciences     21  0.004615\n",
+       "7                  Languages and literature     16  0.003516\n",
+       "8                                Psychology     15  0.003297\n",
+       "9                         Physical sciences     12  0.002637"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>42.048193</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>17.590361</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>141</td>\n      <td>16.987952</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>6.626506</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>3.614458</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>2.771084</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>1.927711</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>1.807229</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>1.445783</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Earth and related environmental sciences</td>\n      <td>349</td>\n      <td>0.076702</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Sociology</td>\n      <td>146</td>\n      <td>0.032087</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Biological sciences</td>\n      <td>141</td>\n      <td>0.030988</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>Social sciences</td>\n      <td>55</td>\n      <td>0.012088</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>Clinical medicine</td>\n      <td>30</td>\n      <td>0.006593</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>Computer and information sciences</td>\n      <td>23</td>\n      <td>0.005055</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>Health sciences</td>\n      <td>21</td>\n      <td>0.004615</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>Languages and literature</td>\n      <td>16</td>\n      <td>0.003516</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>Psychology</td>\n      <td>15</td>\n      <td>0.003297</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>Physical sciences</td>\n      <td>12</td>\n      <td>0.002637</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 218
+     "execution_count": 231
     }
    ],
    "source": [
@@ -2961,30 +2974,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 219,
+   "execution_count": 232,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "   title  count       perc\n",
-       "0   2020    149  17.951807\n",
-       "1   2019     67   8.072289\n",
-       "2   2018     78   9.397590\n",
-       "3   2017     45   5.421687\n",
-       "4   2016     65   7.831325\n",
-       "5   2015     51   6.144578\n",
-       "6   2014     29   3.493976\n",
-       "7   2013     21   2.530120\n",
-       "8   2012     19   2.289157\n",
-       "9   2011    105  12.650602\n",
-       "10  2010     17   2.048193"
+       "   title  count      perc\n",
+       "0   2020    149  0.032747\n",
+       "1   2019     67  0.014725\n",
+       "2   2018     78  0.017143\n",
+       "3   2017     45  0.009890\n",
+       "4   2016     65  0.014285\n",
+       "5   2015     51  0.011209\n",
+       "6   2014     29  0.006374\n",
+       "7   2013     21  0.004615\n",
+       "8   2012     19  0.004176\n",
+       "9   2011    105  0.023076\n",
+       "10  2010     17  0.003736"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>149</td>\n      <td>17.951807</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>8.072289</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>9.397590</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>5.421687</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>7.831325</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>6.144578</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>3.493976</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>2.530120</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>2.289157</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>12.650602</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>2.048193</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2020</td>\n      <td>149</td>\n      <td>0.032747</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2019</td>\n      <td>67</td>\n      <td>0.014725</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2018</td>\n      <td>78</td>\n      <td>0.017143</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2017</td>\n      <td>45</td>\n      <td>0.009890</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2016</td>\n      <td>65</td>\n      <td>0.014285</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>2015</td>\n      <td>51</td>\n      <td>0.011209</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>2014</td>\n      <td>29</td>\n      <td>0.006374</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>2013</td>\n      <td>21</td>\n      <td>0.004615</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>2012</td>\n      <td>19</td>\n      <td>0.004176</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>2011</td>\n      <td>105</td>\n      <td>0.023076</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>2010</td>\n      <td>17</td>\n      <td>0.003736</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 219
+     "execution_count": 232
     }
    ],
    "source": [
@@ -2993,33 +3006,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": 233,
    "metadata": {},
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "             title  count       perc\n",
-       "0          CC0-1.0    209  25.180723\n",
-       "1        CC-BY-4.0    129  15.542169\n",
-       "2        CC-BY-3.0      4   0.481928\n",
-       "3     cc-by-nd-2.0      3   0.361446\n",
-       "4              MIT      2   0.240964\n",
-       "5     CC-BY-NC-4.0      1   0.120482\n",
-       "6  CC-BY-NC-ND-4.0      1   0.120482\n",
-       "7  CC-BY-NC-SA-4.0      1   0.120482\n",
-       "8     CC-BY-SA-4.0      1   0.120482\n",
-       "9          GPL-3.0      1   0.120482"
+       "             title  count      perc\n",
+       "0          CC0-1.0    209  0.045933\n",
+       "1        CC-BY-4.0    129  0.028351\n",
+       "2        CC-BY-3.0      4  0.000879\n",
+       "3     cc-by-nd-2.0      3  0.000659\n",
+       "4              MIT      2  0.000440\n",
+       "5     CC-BY-NC-4.0      1  0.000220\n",
+       "6  CC-BY-NC-ND-4.0      1  0.000220\n",
+       "7  CC-BY-NC-SA-4.0      1  0.000220\n",
+       "8     CC-BY-SA-4.0      1  0.000220\n",
+       "9          GPL-3.0      1  0.000220"
       ],
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>209</td>\n      <td>25.180723</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>15.542169</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.481928</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.361446</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.240964</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.120482</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>title</th>\n      <th>count</th>\n      <th>perc</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>CC0-1.0</td>\n      <td>209</td>\n      <td>0.045933</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>CC-BY-4.0</td>\n      <td>129</td>\n      <td>0.028351</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>CC-BY-3.0</td>\n      <td>4</td>\n      <td>0.000879</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>cc-by-nd-2.0</td>\n      <td>3</td>\n      <td>0.000659</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>MIT</td>\n      <td>2</td>\n      <td>0.000440</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>CC-BY-NC-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>CC-BY-NC-ND-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>CC-BY-NC-SA-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>CC-BY-SA-4.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>GPL-3.0</td>\n      <td>1</td>\n      <td>0.000220</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
      "metadata": {},
-     "execution_count": 220
+     "execution_count": 233
     }
    ],
    "source": [
-    "processTable(citations, \"licenses\") \n"
+    "processTable(citations, \"license) ) \n"
    ]
   },
   {
@@ -3887,10 +3900,13 @@
     }
    ],
    "source": [
+    "perc = 100*(usage[\"totalCount\"]/fos[\"totalCount\"])\n",
+    "\n",
+    "\n",
     "fig = go.Figure(go.Indicator(\n",
     "    mode = \"number+delta\",\n",
     "    value = usage[\"totalCount\"],\n",
-    "    title= {'text': \"Viewed Datasets\"},\n",
+    "    title= {'text': f\"Viewed Datasets ({perc:.2f}%)\"},\n",
     "    # delta = {'position': \"top\", 'reference': usage[\"published\"][0][\"count\"]},\n",
     "    domain = {'x': [0, 1], 'y': [0, 1]}))\n",
     "\n",

--- a/mdc-dataset-discipline/discipline-data-gaps.ipynb
+++ b/mdc-dataset-discipline/discipline-data-gaps.ipynb
@@ -3056,7 +3056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": 256,
    "metadata": {},
    "outputs": [
     {
@@ -3080,7 +3080,7 @@
          },
          "mode": "number+delta",
          "title": {
-          "text": "Viewed Datasets"
+          "text": "Viewed Datasets (0.05%)"
          },
          "type": "indicator",
          "value": 244


### PR DESCRIPTION
## Purpose

Bibliometricians need to have an overall picture of the DataCite data corpus in order to do the analysis. In order to provide this, we will create a notebook with descriptive statistics about the Datacite data corpus broken up by the different dimensions of interest (viz. Discipline, career status, usage, and citations). This document aims to make the first step into creating that notebook by looking directly at the DOI index and exploring the descriptive statistics that will be used.

addresses: https://github.com/CDLUC3/Make-Data-Count/issues/145

## Approach
- Using GraphQL API.
- Showing basic summaries.


#### Open Questions and Pre-Merge TODOs
- Visualisations still need work to be done.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- **Use ReviewNB to review**
- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
